### PR TITLE
fix: Typo in Typescript tip

Fix a typo within Tip example in Typescript configuration file. (#1)

### DIFF
--- a/src/guide/scaling-up/testing.md
+++ b/src/guide/scaling-up/testing.md
@@ -310,7 +310,7 @@ If you are using TypeScript, add `vitest/globals` to the `types` field in your `
 // tsconfig.json
 
 {
- "compileroptions": {
+ "compilerOptions": {
     "types": ["vitest/globals"]
   }
 }


### PR DESCRIPTION
resolves #1
Cherry picked from https://github.com/vuejs/docs/commit/50d2a819e9dca082af6099a515036d3dbb64a74d