### PR TITLE
fix: typo v-bind CSS (#5)

### DIFF
--- a/src/api/utility-types.md
+++ b/src/api/utility-types.md
@@ -130,7 +130,7 @@ Used to augment allowed values in style property bindings.
   :::
   
   :::info See also
-SFC `<style>` tags support linking CSS values to dynamic component state using the `v-bind CSS` function. This allows for custom properties without type augmentation. 
+SFC `<style>` tags support linking CSS values to dynamic component state using the `v-bind` CSS function. This allows for custom properties without type augmentation. 
 
 - [v-bind() in CSS](/api/sfc-css-features.html#v-bind-in-css)
   :::


### PR DESCRIPTION
resolves #5
Cherry picked from https://github.com/vuejs/docs/commit/72b203380bda37f83cbcf31805f969d67b7b0214