### PR TITLE
Reword absent Boolean prop customization note

* Reword absent Boolean prop customization note

Reword sentence about customizing the default behaviour of boolean props. Previous sentence ends up communicating that the built in behaviour is not desirable, which one would assume is not the case or it would not have been built in.

* Boolean prop customization note punctuation fix

Co-authored-by: Natalia Tepluhina <tarya.se@gmail.com>

Co-authored-by: Natalia Tepluhina <tarya.se@gmail.com> (#20)

### DIFF
--- a/src/guide/components/props.md
+++ b/src/guide/components/props.md
@@ -484,7 +484,7 @@ Additional details:
 
 - An absent optional prop other than `Boolean` will have `undefined` value.
 
-- The `Boolean` absent props will be cast to `false`. You should set a `default` value for it in order to get desired behavior.
+- The `Boolean` absent props will be cast to `false`. You can change this by setting a `default` for it — i.e.: `default: undefined` to behave as a non-Boolean prop.
 
 - If a `default` value is specified, it will be used if the resolved prop value is `undefined` - this includes both when the prop is absent, or an explicit `undefined` value is passed.
 


### PR DESCRIPTION
resolves #20
Cherry picked from https://github.com/vuejs/docs/commit/2bdd7f6386d66bd284203427d4e725bd5d75f499