### PR TITLE
Update reactivity-fundamentals.md

Fixed the nesting of "Ref Unwrapping in Arrays and Collections", it was depth 4, should be depth 3 (#33)

### DIFF
--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -514,7 +514,7 @@ console.log(count.value) // 1
 
 Ref unwrapping only happens when nested inside a deep reactive object. It does not apply when it is accessed as a property of a [shallow reactive object](/api/reactivity-advanced.html#shallowreactive).
 
-#### Ref Unwrapping in Arrays and Collections
+### Ref Unwrapping in Arrays and Collections
 
 Unlike reactive objects, there is no unwrapping performed when the ref is accessed as an element of a reactive array or a native collection type like `Map`:
 


### PR DESCRIPTION
resolves #33
Cherry picked from https://github.com/vuejs/docs/commit/3b746085d694be0ee1a3638894989156e565d182