### PR TITLE
feat: add translation

### DIFF
--- a/src/api/general.md
+++ b/src/api/general.md
@@ -101,12 +101,12 @@
 - **Тип**
 
   ```ts
-  // options syntax
+  // синтаксис Options API
   function defineComponent(
     component: ComponentOptions
   ): ComponentConstructor
 
-  // function syntax (requires 3.3+)
+  // синтаксис функции (требуется 3.3+)
   function defineComponent(
     setup: ComponentOptions['setup'],
     extraOptions?: ComponentOptions
@@ -129,7 +129,7 @@
   type FooInstance = InstanceType<typeof Foo>
   ```
 
-  ### Function Signature <sup class="vt-badge" data-text="3.3+" /> {#function-signature}
+  ### Сигнатура Функции <sup class="vt-badge" data-text="3.3+" /> {#function-signature}
 
   `defineComponent()` также имеет альтернативный синтаксис, для совместного использования Composition API и [рендер-функций или JSX](/guide/extras/render-function).
 

--- a/src/guide/extras/reactivity-transform.md
+++ b/src/guide/extras/reactivity-transform.md
@@ -283,8 +283,8 @@ setup(props) {
 
 ## Явное включение {#explicit-opt-in}
 
-:::danger No longer supported in core
-The following only applies up to Vue version 3.3 and below. Support has been removed in Vue core 3.4 and above, and `@vitejs/plugin-vue` 5.0 and above. If you intend to continue using the transform, please migrate to [Vue Macros](https://vue-macros.sxzz.moe/features/reactivity-transform.html) instead.
+:::danger Больше не поддерживается во `vue/core`
+Все ниже применимо только до версии 3.3 или ниже. Поддержка была убрана во `Vue core 3.4` и выше, также как и в `@vitejs/plugin-vue` 5.0 и выше. Если вы хотите пользоваться `transform`, то лучше мигрируйте на [Vue Macros](https://vue-macros.sxzz.moe/features/reactivity-transform.html)
 :::
 
 ### Vite {#vite}

--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -358,8 +358,8 @@ import { createApp } from 'vue'
 
 Также можно добавлять записи и для других зависимостей в import map — но убедитесь, что они указывают на версию ES-модуля библиотеки, которую собираетесь использовать.
 
-:::tip Поддержка Import Maps в браузере
-Import Maps is a relatively new browser feature. Make sure to use a browser within its [support range](https://caniuse.com/import-maps). In particular, it is only supported in Safari 16.4+.
+:::tip Поддержка `Import Maps` в браузере
+`Import Maps` является относительно новой возможностью браузера. Убедитесь, что браузер её [поддерживает](https://caniuse.com/import-maps). В частности, поддерживается в `Safari` с версии `16.4+`.
 :::
 
 :::warning Примечание при использовании в production

--- a/src/guide/typescript/overview.md
+++ b/src/guide/typescript/overview.md
@@ -210,16 +210,14 @@ let x: string | number = 1
 Если используется Vue CLI или настройка на основе webpack, то для использования TypeScript в выражениях шаблонов требуется `vue-loader@^16.8.0`.
 :::
 
-### Usage with TSX {#usage-with-tsx}
+### Использование с `TSX` {#usage-with-tsx}
+Vue также поддерживает создание компонентов с помощью `JSX / TSX`. Подробности описаны в гайде [Рендер-функции & `JSX`](/guide/extras/render-function.html#jsx-tsx)
 
-Vue also supports authoring components with JSX / TSX. Details are covered in the [Render Function & JSX](/guide/extras/render-function.html#jsx-tsx) guide.
+## `Generic` компоненты {#generic-components}
+`Generic` компоненты поддерживаются двумя способами:
 
-## Generic Components {#generic-components}
-
-Generic components are supported in two cases:
-
-- In SFCs: [`<script setup>` with the `generic` attribute](/api/sfc-script-setup.html#generics)
-- Render function / JSX components: [`defineComponent()`'s function signature](/api/general.html#function-signature)
+- В `SFC`: [`<script setup>` с `generic` атрибутом](/api/sfc-script-setup.html#generics)
+- Рендер-функции / `JSX` компоненты: [сигнатура функции `defineComponent()`](/api/general.html#function-signature)
 
 ## Специфические рецепты API {#api-specific-recipes}
 

--- a/src/guide/typescript/overview.md
+++ b/src/guide/typescript/overview.md
@@ -211,7 +211,7 @@ let x: string | number = 1
 :::
 
 ### Использование с `TSX` {#usage-with-tsx}
-Vue также поддерживает создание компонентов с помощью `JSX / TSX`. Подробности описаны в гайде [Рендер-функции & `JSX`](/guide/extras/render-function.html#jsx-tsx)
+Vue также поддерживает создание компонентов с помощью `JSX / TSX`. Подробности описаны в руководстве [Рендер-функции & `JSX`](/guide/extras/render-function.html#jsx-tsx)
 
 ## `Generic` компоненты {#generic-components}
 `Generic` компоненты поддерживаются двумя способами:

--- a/src/guide/typescript/overview.md
+++ b/src/guide/typescript/overview.md
@@ -214,7 +214,7 @@ let x: string | number = 1
 Vue также поддерживает создание компонентов с помощью `JSX / TSX`. Подробности описаны в руководстве [Рендер-функции & `JSX`](/guide/extras/render-function.html#jsx-tsx)
 
 ## `Generic` компоненты {#generic-components}
-`Generic` компоненты поддерживаются двумя способами:
+`Generic` компоненты поддерживаются в двух случаях:
 
 - В `SFC`: [`<script setup>` с `generic` атрибутом](/api/sfc-script-setup.html#generics)
 - Рендер-функции / `JSX` компоненты: [сигнатура функции `defineComponent()`](/api/general.html#function-signature)


### PR DESCRIPTION
## Description of Problem
Добавлены переводы на основе https://github.com/translation-gang/docs-ru/issues/352
## Proposed Solution

## Additional Information
Разорвал safari и версию, так как звучит, как будто только на сафари доступен, когда насамом деле доступен много где, а в сафари только с 16 версии (относительно свежая версия из всех браузеров). Также я старался не использовать английские слова, переписанные русскими буквами, так как я думаю, что это неправильно. Пример: `generic` атрибут, а не дженерик атрибут.